### PR TITLE
DateTime objects break the "date" validator

### DIFF
--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -172,6 +172,9 @@ abstract class AbstractModel {
                     return $exception;
                 break;
             case 'date':
+                if($value instanceof \DateTime) {
+                    $value = $value->format('c');
+                }
                 if (!$this->is_date($value))
                     return $exception;
                 break;

--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -49,6 +49,10 @@ abstract class AbstractModel {
         foreach ($props as $key => $value) {
             if (!array_key_exists($key, $this->_fields))
                 throw new Exception\InvalidPropertyException($this, $key);
+
+            if($value instanceof \DateTime) {
+                $value = $value->format('c');
+            }
             $this->{$key} = $value;
         }
     }
@@ -172,9 +176,6 @@ abstract class AbstractModel {
                     return $exception;
                 break;
             case 'date':
-                if($value instanceof \DateTime) {
-                    $value = $value->format('c');
-                }
                 if (!$this->is_date($value))
                     return $exception;
                 break;


### PR DESCRIPTION
Implemented a check for a DateTime object in the AbstractModel constructor and will convert to string for the value. This is to allow an easier transition for new site owners to implement Riskified as DateTime is extremely common way to represent Date's