### PR TITLE
Get rid of PHP Notice for dispute_type

### DIFF
--- a/src/Riskified/OrderWebhook/Model/DisputeDetails.php
+++ b/src/Riskified/OrderWebhook/Model/DisputeDetails.php
@@ -26,7 +26,7 @@ class DisputeDetails extends AbstractModel {
         'status' => 'string',
         'disputed_at' => 'datetime',
         'expected_resolution_date' => 'datetime',
-        'dispute_type' => string,
+        'dispute_type' => 'string',
         'issuer_poc_phone_number' => 'string'
     );
 }


### PR DESCRIPTION
Use of undefined constant string - assumed 'string'