### PR TITLE
Reformatted namespace declarations

### DIFF
--- a/src/Riskified/Common/Exception/BaseException.php
+++ b/src/Riskified/Common/Exception/BaseException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\Common\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,5 +13,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\Common\Exception;
 
 class BaseException extends \Exception {}

--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -1,19 +1,20 @@
-<?php namespace Riskified\Common;
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+namespace Riskified\Common;
 
 /**
  * Class Riskified

--- a/src/Riskified/Common/Signature/HttpDataSignature.php
+++ b/src/Riskified/Common/Signature/HttpDataSignature.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\Common\Signature;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\Common\Signature;
 
 use Riskified\Common\Riskified;
 

--- a/src/Riskified/DecisionNotification/Exception/AuthorizationException.php
+++ b/src/Riskified/DecisionNotification/Exception/AuthorizationException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\DecisionNotification\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\DecisionNotification\Exception;
 
 /**
  * Class AuthorizationException

--- a/src/Riskified/DecisionNotification/Exception/BadHeaderException.php
+++ b/src/Riskified/DecisionNotification/Exception/BadHeaderException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\DecisionNotification\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\DecisionNotification\Exception;
 
 /**
  * Class BadHeaderException

--- a/src/Riskified/DecisionNotification/Exception/BadPostJsonException.php
+++ b/src/Riskified/DecisionNotification/Exception/BadPostJsonException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\DecisionNotification\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\DecisionNotification\Exception;
 
 /**
  * Class BadPostJsonException

--- a/src/Riskified/DecisionNotification/Exception/NotificationException.php
+++ b/src/Riskified/DecisionNotification/Exception/NotificationException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\DecisionNotification\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\DecisionNotification\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/DecisionNotification/Model/Notification.php
+++ b/src/Riskified/DecisionNotification/Model/Notification.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\DecisionNotification\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\DecisionNotification\Model;
 
 use Riskified\DecisionNotification\Exception;
 

--- a/src/Riskified/OrderWebhook/Exception/ClassMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/ClassMismatchPropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 /**
  * Class ClassMismatchPropertyException

--- a/src/Riskified/OrderWebhook/Exception/CurlException.php
+++ b/src/Riskified/OrderWebhook/Exception/CurlException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/OrderWebhook/Exception/FormatMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/FormatMismatchPropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 /**
  * Class FormatMismatchPropertyException

--- a/src/Riskified/OrderWebhook/Exception/InvalidPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/InvalidPropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 /**
  * Class InvalidPropertyException

--- a/src/Riskified/OrderWebhook/Exception/MalformedJsonException.php
+++ b/src/Riskified/OrderWebhook/Exception/MalformedJsonException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/OrderWebhook/Exception/MissingPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/MissingPropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 /**
  * Class MissingPropertyException

--- a/src/Riskified/OrderWebhook/Exception/MultiplePropertiesException.php
+++ b/src/Riskified/OrderWebhook/Exception/MultiplePropertiesException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/OrderWebhook/Exception/PropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/PropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/OrderWebhook/Exception/TypeMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/TypeMismatchPropertyException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 /**
  * Class TypeMismatchPropertyException

--- a/src/Riskified/OrderWebhook/Exception/UnsuccessfulActionException.php
+++ b/src/Riskified/OrderWebhook/Exception/UnsuccessfulActionException.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Exception;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Exception;
 
 use Riskified\Common\Exception\BaseException;
 

--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 use Riskified\OrderWebhook\Exception;
 

--- a/src/Riskified/OrderWebhook/Model/Address.php
+++ b/src/Riskified/OrderWebhook/Model/Address.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Address

--- a/src/Riskified/OrderWebhook/Model/Attribute.php
+++ b/src/Riskified/OrderWebhook/Model/Attribute.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Attribute

--- a/src/Riskified/OrderWebhook/Model/AuthorizationError.php
+++ b/src/Riskified/OrderWebhook/Model/AuthorizationError.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
     /**
      * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
@@ -13,6 +13,8 @@
      * express or implied. See the License for the specific language governing
      * permissions and limitations under the License.
      */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class AuthorizationError

--- a/src/Riskified/OrderWebhook/Model/ChargeFreePaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ChargeFreePaymentDetails.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class NonCֹhargeablePaymentDetails

--- a/src/Riskified/OrderWebhook/Model/ChargebackDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ChargebackDetails.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class ChargebackDetails

--- a/src/Riskified/OrderWebhook/Model/Checkout.php
+++ b/src/Riskified/OrderWebhook/Model/Checkout.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Checkout

--- a/src/Riskified/OrderWebhook/Model/ClientDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ClientDetails.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php 
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class ClientDetails

--- a/src/Riskified/OrderWebhook/Model/Customer.php
+++ b/src/Riskified/OrderWebhook/Model/Customer.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php 
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Customer

--- a/src/Riskified/OrderWebhook/Model/Decision.php
+++ b/src/Riskified/OrderWebhook/Model/Decision.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Decision

--- a/src/Riskified/OrderWebhook/Model/DecisionDetails.php
+++ b/src/Riskified/OrderWebhook/Model/DecisionDetails.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class DecisionDetails

--- a/src/Riskified/OrderWebhook/Model/DiscountCode.php
+++ b/src/Riskified/OrderWebhook/Model/DiscountCode.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class DiscountCode

--- a/src/Riskified/OrderWebhook/Model/DisputeDetails.php
+++ b/src/Riskified/OrderWebhook/Model/DisputeDetails.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class DisputeDetails

--- a/src/Riskified/OrderWebhook/Model/Fulfillment.php
+++ b/src/Riskified/OrderWebhook/Model/Fulfillment.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Fulfillment

--- a/src/Riskified/OrderWebhook/Model/FulfillmentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/FulfillmentDetails.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class FulfillmentDetails

--- a/src/Riskified/OrderWebhook/Model/LineItem.php
+++ b/src/Riskified/OrderWebhook/Model/LineItem.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class LineItem

--- a/src/Riskified/OrderWebhook/Model/MerchantSettings.php
+++ b/src/Riskified/OrderWebhook/Model/MerchantSettings.php
@@ -1,10 +1,13 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php 
 /**
  * Created by PhpStorm.
  * User: droritbaron
  * Date: 3/29/15
  * Time: 5:29 PM
  */
+
+namespace Riskified\OrderWebhook\Model;
+
 class MerchantSettings extends AbstractModel {
 
     protected $_fields = array(

--- a/src/Riskified/OrderWebhook/Model/Order.php
+++ b/src/Riskified/OrderWebhook/Model/Order.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Order

--- a/src/Riskified/OrderWebhook/Model/OrderCancellation.php
+++ b/src/Riskified/OrderWebhook/Model/OrderCancellation.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class OrderCancellation

--- a/src/Riskified/OrderWebhook/Model/OrderChargeback.php
+++ b/src/Riskified/OrderWebhook/Model/OrderChargeback.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class OrderChargeback

--- a/src/Riskified/OrderWebhook/Model/PaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/PaymentDetails.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class PaymentDetails

--- a/src/Riskified/OrderWebhook/Model/Recipient.php
+++ b/src/Riskified/OrderWebhook/Model/Recipient.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
 * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
 *
@@ -13,6 +13,8 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
 * Class Recipient - used

--- a/src/Riskified/OrderWebhook/Model/Refund.php
+++ b/src/Riskified/OrderWebhook/Model/Refund.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Refund

--- a/src/Riskified/OrderWebhook/Model/RefundDetails.php
+++ b/src/Riskified/OrderWebhook/Model/RefundDetails.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Refund

--- a/src/Riskified/OrderWebhook/Model/Seller.php
+++ b/src/Riskified/OrderWebhook/Model/Seller.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class Seller

--- a/src/Riskified/OrderWebhook/Model/ShippingLine.php
+++ b/src/Riskified/OrderWebhook/Model/ShippingLine.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class ShippingLine

--- a/src/Riskified/OrderWebhook/Model/SocialDetails.php
+++ b/src/Riskified/OrderWebhook/Model/SocialDetails.php
@@ -1,18 +1,20 @@
-<?php namespace Riskified\OrderWebhook\Model;
-    /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License").
-     * You may not use this file except in compliance with the License.
-     * A copy of the License is located at
-     *
-     * http://www.apache.org/licenses/LICENSE-2.0.html
-     *
-     * or in the "license" file accompanying this file. This file is distributed
-     * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-     * express or implied. See the License for the specific language governing
-     * permissions and limitations under the License.
-     */
+<?php
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class SocialDetails

--- a/src/Riskified/OrderWebhook/Model/TaxLine.php
+++ b/src/Riskified/OrderWebhook/Model/TaxLine.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Model;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Model;
 
 /**
  * Class TaxLine

--- a/src/Riskified/OrderWebhook/Transport/AbstractTransport.php
+++ b/src/Riskified/OrderWebhook/Transport/AbstractTransport.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Transport;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Transport;
 
 use Riskified\Common\Env;
 use Riskified\Common\Riskified;

--- a/src/Riskified/OrderWebhook/Transport/CurlTransport.php
+++ b/src/Riskified/OrderWebhook/Transport/CurlTransport.php
@@ -1,4 +1,4 @@
-<?php namespace Riskified\OrderWebhook\Transport;
+<?php
 /**
  * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -13,6 +13,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+namespace Riskified\OrderWebhook\Transport;
 
 use Riskified\OrderWebhook\Exception;
 /**


### PR DESCRIPTION
In our application, our autoloader expects namespaces to be on their own lines. Without this fix, the classes were not being loaded correctly.

While not in the PS-4 standards, most do follow this guideline. Since we had to update it to work on our end, offering it as a PR.
