### PR TITLE
Added support for overidding property validation

### DIFF
--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -39,6 +39,10 @@ class Riskified {
      * @var string validation mode [SKIP, IGNORE_MISSING, ALL]
      */
     public static $validations;
+    /**
+     * @var array array of model key combinations to skip required validation for
+     */
+    public static $validationOverrides = [];
 
 
     /**
@@ -61,6 +65,16 @@ class Riskified {
 
         // suppress timezone warnings:
         date_default_timezone_set(@date_default_timezone_get());
+    }
+
+	/**
+	 * Set an array of model name and property name combinations to ignore
+	 * required validation for
+	 *
+	 * @param array $overrides
+	 */
+    public static function overrideValidations(Array $overrides) {
+	    self::$validationOverrides = $overrides;
     }
 
     public static function getHostByEnv(){

--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -134,14 +134,22 @@ abstract class AbstractModel {
         $this->_enforce_required_keys = $enforce_required_keys;
         $exceptions = array();
         foreach ($this->_fields as $propertyName => $constraints) {
-            $types = explode(' ', $constraints);
-            if (is_null($this->$propertyName)) {
-                if ($this->_enforce_required_keys && end($types) != 'optional') {
-                    $exceptions[] = new Exception\MissingPropertyException($this, $propertyName, $types);
-                }
-            } else {
-                $exceptions = array_merge($exceptions, $this->validate_key($propertyName, $types, $this->$propertyName));
-            }
+	        // check if validation is overridden before testing
+	        $model = (new \ReflectionClass($this))->getShortName();
+	        if (
+	        	!isset(Riskified::$validationOverrides[$model]) ||
+		        !in_array($propertyName, Riskified::$validationOverrides[$model])
+	        ) {
+
+		        $types = explode(' ', $constraints);
+		        if (is_null($this->$propertyName)) {
+			        if ($this->_enforce_required_keys && end($types) != 'optional') {
+				        $exceptions[] = new Exception\MissingPropertyException($this, $propertyName, $types);
+			        }
+		        } else {
+			        $exceptions = array_merge($exceptions, $this->validate_key($propertyName, $types, $this->$propertyName));
+		        }
+	        }
         }
         return array_filter($exceptions);
     }

--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */
 
+use Riskified\Common\Riskified;
 use Riskified\OrderWebhook\Exception;
 
 /**


### PR DESCRIPTION
Added a property to hold validation overrides and a static method to set them allowing end users to set specific Model/Property combinations that should not be validated.

Should be called before loading any models and passed an array of model/property combinations to skip validations for 

https://github.com/Riskified/php_sdk/issues/20