### PR TITLE
DEV-125811: Add optional `payment_type` and `partner_sub_merchant_id` fields

### DIFF
--- a/src/Riskified/OrderWebhook/Model/Order.php
+++ b/src/Riskified/OrderWebhook/Model/Order.php
@@ -74,6 +74,7 @@ class Order extends AbstractModel {
         'vendor_name' => 'string optional',
         'vendor_integration_type' => 'string optional',
         'order_type' => 'string optional',
+        'partner_sub_merchant_id' => 'string optional',
         'submission_reason' => 'string optional',
 
         'shipping_address' => 'object \Address optional',

--- a/src/Riskified/OrderWebhook/Model/PaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/PaymentDetails.php
@@ -49,6 +49,7 @@ class PaymentDetails extends AbstractModel {
         'authorization_error' => 'object \AuthorizationError optional',
         'authentication_result' => 'object \AuthenticationResult optional',
 
-        'cardholder_name' => 'string optional'
+        'cardholder_name' => 'string optional',
+        'payment_type' => 'string optional'
     );
 }


### PR DESCRIPTION
📌 **Related Issues:** [DEV-125811](https://riskified.atlassian.net/browse/DEV-125811)

- [X] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [ ] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

## 📝 Problem Statement

The PHP SDK webhook models were missing support for two optional fields now sent in order payloads:

- `order.payment_details.payment_type` (string)
- `order.partner_sub_merchant_id` (string)

Without these fields in the model definitions, the SDK cannot fully represent incoming webhook payloads.

## 📝 Solution Overview

Updated Order Webhook model schemas to include both optional string fields:

- `src/Riskified/OrderWebhook/Model/PaymentDetails.php`
  - Added: `payment_type => 'string optional'`
- `src/Riskified/OrderWebhook/Model/Order.php`
  - Added: `partner_sub_merchant_id => 'string optional'`
 
## 📝 Notes

- `partner_sub_merchant_id` belongs to the `Order` model (top-level `order.*`), not `PaymentDetails`.

[DEV-125811]: https://riskified.atlassian.net/browse/DEV-125811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ