### PR TITLE
DEV-131521: Add account_identity and account_balance support to PaymentDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified PHP SDK
 =================
 
-version: 1.10.2
+version: 1.11.0
 -------------------
 
 See *samples/* for examples on how to use this SDK.

--- a/sample/account_action_request.php
+++ b/sample/account_action_request.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sample/callback.php
+++ b/sample/callback.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sample/order_full_flow.php
+++ b/sample/order_full_flow.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sample/order_marketplace_create.php
+++ b/sample/order_marketplace_create.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sample/order_simple_submit.php
+++ b/sample/order_simple_submit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/sample/run_callback_server.sh
+++ b/sample/run_callback_server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.

--- a/sample/upload_historical.php
+++ b/sample/upload_historical.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/Common/Env.php
+++ b/src/Riskified/Common/Env.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/Common/Exception/BaseException.php
+++ b/src/Riskified/Common/Exception/BaseException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\Common\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -20,7 +20,7 @@
  * @package Riskified\Common
  */
 class Riskified {
-    const VERSION = '1.10.3';
+    const VERSION = '1.11.0';
     const API_VERSION = '2';
 
     /**

--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -20,7 +20,7 @@
  * @package Riskified\Common
  */
 class Riskified {
-    const VERSION = '1.10.2';
+    const VERSION = '1.10.3';
     const API_VERSION = '2';
 
     /**

--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -1,7 +1,7 @@
 <?php namespace Riskified\Common;
 
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/Common/Signature/HttpDataSignature.php
+++ b/src/Riskified/Common/Signature/HttpDataSignature.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\Common\Signature;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/Common/Validations.php
+++ b/src/Riskified/Common/Validations.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/DecisionNotification/Exception/AuthorizationException.php
+++ b/src/Riskified/DecisionNotification/Exception/AuthorizationException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\DecisionNotification\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/DecisionNotification/Exception/BadHeaderException.php
+++ b/src/Riskified/DecisionNotification/Exception/BadHeaderException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\DecisionNotification\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/DecisionNotification/Exception/BadPostJsonException.php
+++ b/src/Riskified/DecisionNotification/Exception/BadPostJsonException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\DecisionNotification\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/DecisionNotification/Exception/NotificationException.php
+++ b/src/Riskified/DecisionNotification/Exception/NotificationException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\DecisionNotification\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/DecisionNotification/Model/Notification.php
+++ b/src/Riskified/DecisionNotification/Model/Notification.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\DecisionNotification\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/ClassMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/ClassMismatchPropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/CurlException.php
+++ b/src/Riskified/OrderWebhook/Exception/CurlException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/FormatMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/FormatMismatchPropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/InvalidPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/InvalidPropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/MalformedJsonException.php
+++ b/src/Riskified/OrderWebhook/Exception/MalformedJsonException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/MissingPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/MissingPropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/MultiplePropertiesException.php
+++ b/src/Riskified/OrderWebhook/Exception/MultiplePropertiesException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/PropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/PropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/TypeMismatchPropertyException.php
+++ b/src/Riskified/OrderWebhook/Exception/TypeMismatchPropertyException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Exception/UnsuccessfulActionException.php
+++ b/src/Riskified/OrderWebhook/Exception/UnsuccessfulActionException.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Exception;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AbstractModel.php
+++ b/src/Riskified/OrderWebhook/Model/AbstractModel.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AccountBalance.php
+++ b/src/Riskified/OrderWebhook/Model/AccountBalance.php
@@ -1,0 +1,30 @@
+<?php namespace Riskified\OrderWebhook\Model;
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Class AccountBalance
+ * Represents account balance information from a financial data provider.
+ * @package Riskified\OrderWebhook\Model
+ */
+class AccountBalance extends AbstractModel {
+
+    protected $_fields = array(
+        'available_balance' => 'float',
+        'service_name' => 'string /^(:?plaid|mx|stripe|truelayer|klarna|visa|mastercard|yodlee)$/',
+        'updated_at' => 'date',
+        'currency_code' => 'string /^[A-Z]{3}$/i'
+    );
+}

--- a/src/Riskified/OrderWebhook/Model/AccountBalance.php
+++ b/src/Riskified/OrderWebhook/Model/AccountBalance.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AccountIdentity.php
+++ b/src/Riskified/OrderWebhook/Model/AccountIdentity.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AccountIdentity.php
+++ b/src/Riskified/OrderWebhook/Model/AccountIdentity.php
@@ -1,0 +1,31 @@
+<?php namespace Riskified\OrderWebhook\Model;
+/**
+ * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Class AccountIdentity
+ * Represents identity information associated with a payment account.
+ * All fields are optional.
+ * @package Riskified\OrderWebhook\Model
+ */
+class AccountIdentity extends AbstractModel {
+
+    protected $_fields = array(
+        'names' => 'array string optional',
+        'addresses' => 'array object \Address optional',
+        'phone_numbers' => 'array string optional',
+        'emails' => 'array string optional'
+    );
+}

--- a/src/Riskified/OrderWebhook/Model/Address.php
+++ b/src/Riskified/OrderWebhook/Model/Address.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Attribute.php
+++ b/src/Riskified/OrderWebhook/Model/Attribute.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AuthenticationResult.php
+++ b/src/Riskified/OrderWebhook/Model/AuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/AuthorizationError.php
+++ b/src/Riskified/OrderWebhook/Model/AuthorizationError.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ChargeFreePaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ChargeFreePaymentDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ChargebackDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ChargebackDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Checkout.php
+++ b/src/Riskified/OrderWebhook/Model/Checkout.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ClientDetails.php
+++ b/src/Riskified/OrderWebhook/Model/ClientDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ContactMethod.php
+++ b/src/Riskified/OrderWebhook/Model/ContactMethod.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Customer.php
+++ b/src/Riskified/OrderWebhook/Model/Customer.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/CustomerCreate.php
+++ b/src/Riskified/OrderWebhook/Model/CustomerCreate.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/CustomerReachOut.php
+++ b/src/Riskified/OrderWebhook/Model/CustomerReachOut.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/CustomerUpdate.php
+++ b/src/Riskified/OrderWebhook/Model/CustomerUpdate.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Decision.php
+++ b/src/Riskified/OrderWebhook/Model/Decision.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/DecisionDetails.php
+++ b/src/Riskified/OrderWebhook/Model/DecisionDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/DiscountCode.php
+++ b/src/Riskified/OrderWebhook/Model/DiscountCode.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/DisputeDetails.php
+++ b/src/Riskified/OrderWebhook/Model/DisputeDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Fulfillment.php
+++ b/src/Riskified/OrderWebhook/Model/Fulfillment.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/FulfillmentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/FulfillmentDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/LineItem.php
+++ b/src/Riskified/OrderWebhook/Model/LineItem.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Login.php
+++ b/src/Riskified/OrderWebhook/Model/Login.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/LoginStatus.php
+++ b/src/Riskified/OrderWebhook/Model/LoginStatus.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Logout.php
+++ b/src/Riskified/OrderWebhook/Model/Logout.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Order.php
+++ b/src/Riskified/OrderWebhook/Model/Order.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/OrderCancellation.php
+++ b/src/Riskified/OrderWebhook/Model/OrderCancellation.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/OrderChargeback.php
+++ b/src/Riskified/OrderWebhook/Model/OrderChargeback.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Passenger.php
+++ b/src/Riskified/OrderWebhook/Model/Passenger.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/PaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/PaymentDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/PaymentDetails.php
+++ b/src/Riskified/OrderWebhook/Model/PaymentDetails.php
@@ -50,6 +50,9 @@ class PaymentDetails extends AbstractModel {
         'authentication_result' => 'object \AuthenticationResult optional',
 
         'cardholder_name' => 'string optional',
-        'payment_type' => 'string optional'
+        'payment_type' => 'string optional',
+
+        'account_identity' => 'object \AccountIdentity optional',
+        'account_balance' => 'object \AccountBalance optional'
     );
 }

--- a/src/Riskified/OrderWebhook/Model/Recipient.php
+++ b/src/Riskified/OrderWebhook/Model/Recipient.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
-* Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+* Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License").
 * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Redeem.php
+++ b/src/Riskified/OrderWebhook/Model/Redeem.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Refund.php
+++ b/src/Riskified/OrderWebhook/Model/Refund.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/RefundDetails.php
+++ b/src/Riskified/OrderWebhook/Model/RefundDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ResetPasswordRequest.php
+++ b/src/Riskified/OrderWebhook/Model/ResetPasswordRequest.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Seller.php
+++ b/src/Riskified/OrderWebhook/Model/Seller.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/SessionDetails.php
+++ b/src/Riskified/OrderWebhook/Model/SessionDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/ShippingLine.php
+++ b/src/Riskified/OrderWebhook/Model/ShippingLine.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/SocialDetails.php
+++ b/src/Riskified/OrderWebhook/Model/SocialDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
     /**
-     * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+     * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
      *
      * Licensed under the Apache License, Version 2.0 (the "License").
      * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/TaxLine.php
+++ b/src/Riskified/OrderWebhook/Model/TaxLine.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/Verification.php
+++ b/src/Riskified/OrderWebhook/Model/Verification.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/VerificationSessionDetails.php
+++ b/src/Riskified/OrderWebhook/Model/VerificationSessionDetails.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Model/WishlistChanges.php
+++ b/src/Riskified/OrderWebhook/Model/WishlistChanges.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Model;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Transport/AbstractTransport.php
+++ b/src/Riskified/OrderWebhook/Transport/AbstractTransport.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Transport;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/OrderWebhook/Transport/CurlTransport.php
+++ b/src/Riskified/OrderWebhook/Transport/CurlTransport.php
@@ -1,6 +1,6 @@
 <?php namespace Riskified\OrderWebhook\Transport;
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/Riskified/autoloader.php
+++ b/src/Riskified/autoloader.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2013-2015 Riskified.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2013-2026 Riskified.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.


### PR DESCRIPTION
## 📌 Related Issues: [DEV-131521](https://riskified.atlassian.net/browse/DEV-131521)

## ✅ Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [ ] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

## 📝 Problem Statement

`PaymentDetails` lacked support for `account_identity` and `account_balance` objects, needed to pass account holder identity information and real-time balance data (via providers like Plaid, MX, etc.) on bank transfer/ACH orders.

## 📝 Solution Overview

Added two new optional fields to `PaymentDetails`:

- **`account_identity`** — holds names, addresses, phone numbers and emails associated with the payment account
- **`account_balance`** — holds available balance, service provider, timestamp and currency code

**New files:**
- `AccountIdentity.php` — model with 4 optional fields (`names`, `addresses`, `phone_numbers`, `emails`)
- `AccountBalance.php` — model with 4 required fields (`available_balance`, `service_name`, `updated_at`, `currency_code`); `service_name` validated via regex against supported providers (`plaid`, `mx`, `stripe`, `truelayer`, `klarna`, `visa`, `mastercard`, `yodlee`)

**Modified:**
- `PaymentDetails.php` — added `account_identity` and `account_balance` optional fields


[DEV-131521]: https://riskified.atlassian.net/browse/DEV-131521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ