### PR TITLE
DEV-132452: add ai_agent field and source value to Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified PHP SDK
 =================
 
-version: 1.11.0
+version: 1.12.0
 -------------------
 
 See *samples/* for examples on how to use this SDK.

--- a/src/Riskified/Common/Riskified.php
+++ b/src/Riskified/Common/Riskified.php
@@ -20,7 +20,7 @@
  * @package Riskified\Common
  */
 class Riskified {
-    const VERSION = '1.11.0';
+    const VERSION = '1.12.0';
     const API_VERSION = '2';
 
     /**

--- a/src/Riskified/OrderWebhook/Model/Order.php
+++ b/src/Riskified/OrderWebhook/Model/Order.php
@@ -55,7 +55,7 @@ class Order extends AbstractModel {
         'landing_site' => 'string optional',
         'landing_site_ref' => 'string optional',
         'location_id' => 'string optional',
-        'source' => 'string /^(:?desktop_web|mobile_app|mobile_web|web|chat|third_party|phone|in_store|shopify_draft_order|unknown|mobile_app_android|mobile_app_ios)$/',
+        'source' => 'string /^(:?desktop_web|mobile_app|mobile_web|web|chat|third_party|phone|in_store|shopify_draft_order|unknown|mobile_app_android|mobile_app_ios|ai_agent)$/',
         'source_identifier' => 'string optional',
         'source_name' => 'string optional',
         'source_url' => 'string optional',
@@ -76,6 +76,7 @@ class Order extends AbstractModel {
         'order_type' => 'string optional',
         'partner_sub_merchant_id' => 'string optional',
         'submission_reason' => 'string optional',
+        'ai_agent' => 'string /^(?:chatgpt|gemini|copilot|perplexity)$/ optional',
 
         'shipping_address' => 'object \Address optional',
         'billing_address' => 'object \Address optional',

--- a/tests/OrderWebhook/Model/OrderTest.php
+++ b/tests/OrderWebhook/Model/OrderTest.php
@@ -3,6 +3,7 @@
 namespace Riskified\Tests\OrderWebhook\Model;
 
 use PHPUnit\Framework\TestCase;
+use Riskified\OrderWebhook\Exception\MultiplePropertiesException;
 use Riskified\OrderWebhook\Model\Order;
 
 class OrderTest extends TestCase
@@ -21,4 +22,36 @@ class OrderTest extends TestCase
         $json = $order->toJson();
         $this->assertStringContainsString('"partner_sub_merchant_id":"merchant-abc"', $json);
     }
+
+    /**
+     * @dataProvider acceptedAiAgentValues
+     */
+    public function testAiAgentAcceptsKnownValues(string $value): void
+    {
+        $order = new Order();
+        $order->ai_agent = $value;
+
+        // validate(false) checks formats only, skipping required-field enforcement.
+        $this->assertTrue($order->validate(false));
+    }
+
+    public static function acceptedAiAgentValues(): array
+    {
+        return [
+            ['chatgpt'],
+            ['gemini'],
+            ['copilot'],
+            ['perplexity'],
+        ];
+    }
+
+    public function testAiAgentRejectsUnknownValue(): void
+    {
+        $order = new Order();
+        $order->ai_agent = 'unknown_bot';
+
+        $this->expectException(MultiplePropertiesException::class);
+        $order->validate(false);
+    }
+
 }


### PR DESCRIPTION
## 📌 Related Issues: [DEV-132452](https://riskified.atlassian.net/browse/DEV-132452)


## ✅ Type of Change

<!-- Uncomment the relevant option(s) -->

- [x] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [ ] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

##  Features added

1. added a new field field called ai_agent to the order request that supports an enum
2. added a new option for source called `ai_agent` 





[DEV-132452]: https://riskified.atlassian.net/browse/DEV-132452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ